### PR TITLE
Work around linking issues from rust-fuzz/afl.rs#141, rust-lang/rust#53945

### DIFF
--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -190,6 +190,12 @@ where
         common::afl_llvm_rt_dir().display()
     );
 
+    // work around https://github.com/rust-fuzz/afl.rs/issues/141 /
+    // https://github.com/rust-lang/rust/issues/53945, can be removed once
+    // those are fixed.
+    rustflags.push_str("-Clink-arg=-fuse-ld=gold");
+    rustdocflags.push_str("-Clink-arg=-fuse-ld=gold");
+
     // add user provided flags
     rustflags.push_str(&env::var("RUSTFLAGS").unwrap_or_default());
     rustdocflags.push_str(&env::var("RUSTDOCFLAGS").unwrap_or_default());


### PR DESCRIPTION
rust-fuzz/afl.rs#141 + rust-lang/rust#53945 track issues with linkage
which regressed when rust updated to llvm 8. This commit adds a work
around for such issues for cargo-afl. This helps with the ergonomics of
cargo-afl, particularly for those less familiar with the project and the
above issues.

These changes can be safely removed once patches are landed in llvm and
rust updates to use the patched version.