### PR TITLE
Fix broken OS detection

### DIFF
--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -190,7 +190,7 @@ where
         common::afl_llvm_rt_dir().display()
     );
 
-    if cfg!(linux) {
+    if cfg!(target_os = "linux") {
         // work around https://github.com/rust-fuzz/afl.rs/issues/141 /
         // https://github.com/rust-lang/rust/issues/53945, can be removed once
         // those are fixed.

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -194,8 +194,8 @@ where
         // work around https://github.com/rust-fuzz/afl.rs/issues/141 /
         // https://github.com/rust-lang/rust/issues/53945, can be removed once
         // those are fixed.
-        rustflags.push_str("-Clink-arg=-fuse-ld=gold");
-        rustdocflags.push_str("-Clink-arg=-fuse-ld=gold");
+        rustflags.push_str("-Clink-arg=-fuse-ld=gold ");
+        rustdocflags.push_str("-Clink-arg=-fuse-ld=gold ");
     }
 
     // add user provided flags


### PR DESCRIPTION
The #141 workaround was actually fully disabled because the OS condition
was wrong. This fixes the workaround.