### PR TITLE
Add build support for AFL on ARM

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ fn main() {
     build_afl_llvm_runtime();
 }
 
+#[cfg(not(target_arch = "arm"))]
 fn build_afl(out_dir: &Path) {
     let status = Command::new("make")
         .current_dir(AFL_SRC_PATH)
@@ -24,6 +25,23 @@ fn build_afl(out_dir: &Path) {
         .env("AFL_TRACE_PC", "1")
         .env("DESTDIR", out_dir)
         .env("PREFIX", "")
+        .status()
+        .expect("could not run 'make'");
+    assert!(status.success());
+}
+
+#[cfg(target_arch = "arm")]
+fn build_afl(out_dir: &Path) {
+    let status = Command::new("make")
+        .current_dir(AFL_SRC_PATH)
+        .args(&["clean", "all", "install"])
+        // Rely on LLVM’s built-in execution tracing feature instead of AFL’s
+        // LLVM passi instrumentation.
+        .env("AFL_TRACE_PC", "1")
+        .env("DESTDIR", out_dir)
+        .env("PREFIX", "")
+        // sets AFL_NO_X86 to compile for ARM arch
+        .env("AFL_NO_X86", "1")
         .status()
         .expect("could not run 'make'");
     assert!(status.success());


### PR DESCRIPTION
Installing `afl.rs` on ARM results in this error:

```
$ cargo build
...
Oops, looks like your compiler can't generate x86 code.

Don't panic! You can use the LLVM or QEMU mode, but see docs/INSTALL first.
(To ignore this error, set AFL_NO_X86=1 and try again.)

Makefile:52: recipe for target 'test_x86' failed

--- stderr
/tmp/ccI7TNQZ.s: Assembler messages:
/tmp/ccI7TNQZ.s:28: Error: bad instruction `xorb %al,%al'
```

To fix, we can add another `.env()` mapping to set `AFL_NO_X86` when executing `build_afl()` on ARM.