### PR TITLE
Expose common in the public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
 use std::io::{self, Read};
 use std::{panic, process};
 
-pub mod common;
+mod common;
+pub use common::*;
 
 /// Utility that reads a `Vec` of bytes from standard input (stdin)
 /// and passes it to `closure`. All panics that occur within

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 use std::io::{self, Read};
 use std::{panic, process};
 
+pub mod common;
+
 /// Utility that reads a `Vec` of bytes from standard input (stdin)
 /// and passes it to `closure`. All panics that occur within
 /// `closure` will be treated as aborts. This is done so that


### PR DESCRIPTION
I'd like to be able to use the methods in common to find the afl built by afl.rs as part of a crate I'm working on's build system.

I'm not strongly wed to this approach, so any feedback is welcome!