### PR TITLE
Add option to kill afl-fuzz after a time limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "afl"
 version = "0.5.2"
 dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -13,8 +13,11 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "atty"
@@ -38,14 +41,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.30.0"
+version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -91,7 +94,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -106,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -147,20 +150,20 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
-"checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = "0.5.2"
 dependencies = [
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -20,7 +21,7 @@ name = "atty"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -51,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.37"
+version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -98,7 +99,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -151,7 +152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
-"checksum libc 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)" = "56aebce561378d99a0bb578f8cb15b6114d2a1814a6c7949bbe646d968bb4fa9"
+"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rustc_version = "0.2"
 
 [dependencies]
 cc = "1.0"
-clap = "2.29"
+clap = "2.33"
 libc = "0.2.66"
 rustc_version = "0.2"
 xdg = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ rustc_version = "0.2"
 [dependencies]
 cc = "1.0"
 clap = "2.29"
+libc = "0.2.66"
 rustc_version = "0.2"
 xdg = "2.1"

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -23,6 +23,8 @@ fn main() {
     }
 
     let app_matches = clap_app().get_matches();
+    // This unwrap is okay because we set SubcommandRequiredElseHelp at the top level, and afl is
+    // the only subcommand
     let afl_matches = app_matches.subcommand_matches("afl").unwrap();
 
     match afl_matches.subcommand() {
@@ -84,6 +86,7 @@ fn main() {
                 .unwrap_or_default();
             run_cargo(subcommand, args);
         }
+        // unreachable due to SubcommandRequiredElseHelp on "afl" subcommand
         (_, None) => unreachable!(),
     }
 }
@@ -92,19 +95,16 @@ fn clap_app() -> clap::App<'static, 'static> {
     use clap::{App, AppSettings::{
         AllowExternalSubcommands,
         AllowLeadingHyphen,
-        ArgRequiredElseHelp,
         DisableHelpSubcommand,
+        DisableHelpFlags,
         DisableVersion,
         SubcommandRequiredElseHelp,
-        TrailingVarArg,
     }, Arg, SubCommand};
 
     App::new("cargo afl").bin_name("cargo").setting(SubcommandRequiredElseHelp).subcommand(
         SubCommand::with_name("afl")
             .version(crate_version!())
-            .setting(ArgRequiredElseHelp)
             .setting(SubcommandRequiredElseHelp)
-            .setting(TrailingVarArg)
             .setting(AllowExternalSubcommands)
             .usage("cargo afl [SUBCOMMAND or Cargo SUBCOMMAND]")
             .after_help(
@@ -116,9 +116,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-analyze")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-analyze args").multiple(true)),
             )
             .subcommand(
@@ -126,9 +125,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-cmin")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-cmin args").multiple(true)),
             )
             .subcommand(
@@ -136,9 +134,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-fuzz")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("max_total_time").long("max_total_time").takes_value(true).help("Maximum amount of time to run the fuzzer"))
                     .arg(Arg::with_name("afl-fuzz args").multiple(true)),
             )
@@ -147,9 +144,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-gotcpu")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-gotcpu args").multiple(true)),
             )
             .subcommand(
@@ -157,9 +153,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-plot")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-plot args").multiple(true)),
             )
             .subcommand(
@@ -167,9 +162,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-showmap")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-showmap args").multiple(true)),
             )
             .subcommand(
@@ -177,9 +171,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-tmin")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-tmin args").multiple(true)),
             )
             .subcommand(
@@ -187,9 +180,8 @@ fn clap_app() -> clap::App<'static, 'static> {
                     .about("Invoke afl-whatsup")
                     .setting(AllowLeadingHyphen)
                     .setting(DisableHelpSubcommand)
+                    .setting(DisableHelpFlags)
                     .setting(DisableVersion)
-                    .arg(Arg::with_name("h").short("h").hidden(true))
-                    .arg(Arg::with_name("help").long("help").hidden(true))
                     .arg(Arg::with_name("afl-whatsup args").multiple(true)),
             ),
     )

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -22,113 +22,170 @@ fn main() {
         process::exit(1);
     }
 
-    let _ = clap_app().get_matches();
+    let app_matches = clap_app().get_matches();
+    let afl_matches = app_matches.subcommand_matches("afl").unwrap();
 
-    let mut args = env::args().skip(2).peekable(); // skip `cargo` and `afl`
-    match args.peek().map(|s| &**s) {
-        Some("analyze") => run_afl(args, "afl-analyze"),
-        Some("cmin") => run_afl(args, "afl-cmin"),
-        Some("fuzz") => run_afl(args, "afl-fuzz"),
-        Some("gotcpu") => run_afl(args, "afl-got-cpu"),
-        Some("plot") => run_afl(args, "afl-plot"),
-        Some("showmap") => run_afl(args, "afl-showmap"),
-        Some("tmin") => run_afl(args, "afl-tmin"),
-        Some("whatsup") => run_afl(args, "afl-whatsup"),
-        _ => run_cargo(args),
+    match afl_matches.subcommand() {
+        ("analyze", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-analyze args")
+                .unwrap_or_default();
+            run_afl(args, "afl-analyze");
+        }
+        ("cmin", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-cmin args")
+                .unwrap_or_default();
+            run_afl(args, "afl-cmin");
+        }
+        ("fuzz", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-fuzz args")
+                .unwrap_or_default();
+            run_afl(args, "afl-fuzz");
+        }
+        ("gotcpu", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-gotcpu args")
+                .unwrap_or_default();
+            run_afl(args, "afl-gotcpu");
+        }
+        ("plot", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-plot args")
+                .unwrap_or_default();
+            run_afl(args, "afl-plot");
+        }
+        ("showmap", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-showmap args")
+                .unwrap_or_default();
+            run_afl(args, "afl-showmap");
+        }
+        ("tmin", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-tmin args")
+                .unwrap_or_default();
+            run_afl(args, "afl-tmin");
+        }
+        ("whatsup", Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("afl-whatsup args")
+                .unwrap_or_default();
+            run_afl(args, "afl-whatsup");
+        }
+        (subcommand, Some(sub_matches)) => {
+            let args = sub_matches
+                .values_of_os("")
+                .unwrap_or_default();
+            run_cargo(subcommand, args);
+        }
+        (_, None) => unreachable!(),
     }
 }
 
 fn clap_app() -> clap::App<'static, 'static> {
-    clap::App::new("cargo afl").bin_name("cargo").subcommand(
-        clap::SubCommand::with_name("afl")
+    use clap::{App, AppSettings::{
+        AllowExternalSubcommands,
+        AllowLeadingHyphen,
+        ArgRequiredElseHelp,
+        DisableHelpSubcommand,
+        DisableVersion,
+        SubcommandRequiredElseHelp,
+        TrailingVarArg,
+    }, Arg, SubCommand};
+
+    App::new("cargo afl").bin_name("cargo").setting(SubcommandRequiredElseHelp).subcommand(
+        SubCommand::with_name("afl")
             .version(crate_version!())
-            .setting(clap::AppSettings::ArgRequiredElseHelp)
-            .setting(clap::AppSettings::TrailingVarArg)
-            .setting(clap::AppSettings::AllowExternalSubcommands)
+            .setting(ArgRequiredElseHelp)
+            .setting(SubcommandRequiredElseHelp)
+            .setting(TrailingVarArg)
+            .setting(AllowExternalSubcommands)
             .usage("cargo afl [SUBCOMMAND or Cargo SUBCOMMAND]")
             .after_help(
                 "In addition to the subcommands above, Cargo subcommands are also \
                  supported (see `cargo help` for a list of all Cargo subcommands).",
             )
             .subcommand(
-                clap::SubCommand::with_name("analyze")
+                SubCommand::with_name("analyze")
                     .about("Invoke afl-analyze")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-analyze args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-analyze args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("cmin")
+                SubCommand::with_name("cmin")
                     .about("Invoke afl-cmin")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-cmin args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-cmin args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("fuzz")
+                SubCommand::with_name("fuzz")
                     .about("Invoke afl-fuzz")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-fuzz args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-fuzz args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("gotcpu")
+                SubCommand::with_name("gotcpu")
                     .about("Invoke afl-gotcpu")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-gotcpu args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-gotcpu args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("plot")
+                SubCommand::with_name("plot")
                     .about("Invoke afl-plot")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-plot args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-plot args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("showmap")
+                SubCommand::with_name("showmap")
                     .about("Invoke afl-showmap")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-showmap args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-showmap args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("tmin")
+                SubCommand::with_name("tmin")
                     .about("Invoke afl-tmin")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-tmin args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-tmin args").multiple(true)),
             )
             .subcommand(
-                clap::SubCommand::with_name("whatsup")
+                SubCommand::with_name("whatsup")
                     .about("Invoke afl-whatsup")
-                    .setting(clap::AppSettings::AllowLeadingHyphen)
-                    .setting(clap::AppSettings::DisableHelpSubcommand)
-                    .setting(clap::AppSettings::DisableVersion)
-                    .arg(clap::Arg::with_name("h").short("h").hidden(true))
-                    .arg(clap::Arg::with_name("help").long("help").hidden(true))
-                    .arg(clap::Arg::with_name("afl-whatsup args").multiple(true)),
+                    .setting(AllowLeadingHyphen)
+                    .setting(DisableHelpSubcommand)
+                    .setting(DisableVersion)
+                    .arg(Arg::with_name("h").short("h").hidden(true))
+                    .arg(Arg::with_name("help").long("help").hidden(true))
+                    .arg(Arg::with_name("afl-whatsup args").multiple(true)),
             ),
     )
 }
@@ -217,13 +274,13 @@ where
 {
     let cmd_path = common::afl_dir().join("bin").join(cmd);
     let status = Command::new(cmd_path)
-        .args(args.into_iter().skip(1)) // skip afl sub-command
+        .args(args)
         .status()
         .unwrap();
     process::exit(status.code().unwrap_or(1));
 }
 
-fn run_cargo<I, S>(args: I)
+fn run_cargo<I, S>(subcommand: &str, args: I)
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
@@ -284,7 +341,8 @@ where
     rustdocflags.push_str(&env::var("RUSTDOCFLAGS").unwrap_or_default());
 
     let status = Command::new(cargo_path)
-        .args(args) // skip `cargo` and `afl`
+        .arg(subcommand)
+        .args(args)
         .env("RUSTFLAGS", &rustflags)
         .env("RUSTDOCFLAGS", &rustdocflags)
         .env("ASAN_OPTIONS", asan_options)

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -1,4 +1,4 @@
-use clap::crate_version;
+use clap::{crate_version, value_t};
 
 use std::env;
 use std::ffi::OsStr;
@@ -46,8 +46,9 @@ fn main() {
                 .unwrap_or_default();
             let timeout = sub_matches
                 .value_of("max_total_time")
-                .map(str::parse::<u64>)
-                .map(Result::unwrap);
+                .map(|_| {
+                    value_t!(sub_matches, "max_total_time", u64).unwrap_or_else(|e| e.exit())
+                });
             run_afl(args, "afl-fuzz", timeout);
         }
         ("gotcpu", Some(sub_matches)) => {


### PR DESCRIPTION
This PR adds a new option to `cargo afl fuzz`, `--max_total_time`, to limit how long afl-fuzz runs for. The new option will enable implementing rust-fuzz/targets#107. When this option is specified, `cargo-afl` will wait that many seconds and kill `afl-fuzz`, if it's still running. I had to refactor how command line arguments were passed around, as well, so that this new option didn't get passed to `afl`.