### PR TITLE
Use resettable-lazy-static.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ clap = "2.33"
 libc = "0.2.66"
 rustc_version = "0.2"
 xdg = "2.1"
+lazy_static = { version = "1.4.0", optional = true }
+
+[features]
+reset_lazy_static = ["lazy_static"]

--- a/README.md
+++ b/README.md
@@ -31,3 +31,21 @@ Screen recording of AFL running on Rust code.
 [rustup]: https://rustup.rs/
 [american-fuzzy-lop]: http://lcamtuf.coredump.cx/afl/
 [rust]: https://www.rust-lang.org
+
+## `lazy_static` variables
+
+`lazy_static` variables present problems for AFL's persistent mode, which afl.rs uses. Such variables can cause AFL to give incorrectly low stability reports, or fail to report timeouts, for example.
+
+To address such problems, rust-fuzz provides a ["resettable" version](https://github.com/rust-fuzz/resettable-lazy-static.rs) of `lazy_static`. To use it, make the following two changes to your target's `Cargo.toml` file.
+
+1. Add a `[patch.crates-io]` section and overide the `lazy_static` dependency with the rust-fuzz version:
+    ```toml
+    [patch.crates-io]
+    lazy_static = { git = "https://github.com/rust-fuzz/resettable-lazy-static.rs" }
+
+    ```
+2. Enable the `reset_lazy_staic` feature on afl.rs:
+    ```toml
+    [dependencies]
+    afl = { version = "0.6.0", features = ["reset_lazy_static"] }
+    ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,12 @@ where
             // process before the stack frames are unwinded.
             std::process::abort();
         }
+        // The version of lazy_static.rs at https://github.com/rust-fuzz/resettable-lazy-static.rs
+        // provides the `reset` function.
+        #[cfg(feature = "reset_lazy_static")]
+        unsafe {
+            lazy_static::lazy::reset();
+        }
         input.clear();
     }
 }


### PR DESCRIPTION
This PR addresses #164.

As promised in that issue, this PR:
* adds a call to `lazy_static::lazy::reset()`, guarded by a new feature, `reset_lazy_static`, and
* updates the README with instructions on how to use the new feature.

The changes are tested by [this project](https://github.com/smoelius/fuzz-lazy-static).

Regarding the latter bullet, I considered whether the instructions would be better suited for the rust-fuzz book. Ultimately, I wasn't sure where they should go in the book, so I went ahead with the README.

Anyway, I am very much open to suggestions regarding the instructions, both in their content and their placement.