### PR TITLE
Qualify uses of `__fuzz!` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,14 +205,14 @@ where
 /// ```
 #[macro_export]
 macro_rules! fuzz {
-    ( $($x:tt)* ) => { __fuzz!(true, $($x)*) }
+    ( $($x:tt)* ) => { afl::__fuzz!(true, $($x)*) }
 }
 
 /// Like `fuzz!` above, but panics that are caught inside the fuzzed code are not turned into
 /// crashes.
 #[macro_export]
 macro_rules! fuzz_nohook {
-    ( $($x:tt)* ) => { __fuzz!(false, $($x)*) }
+    ( $($x:tt)* ) => { afl::__fuzz!(false, $($x)*) }
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,26 +205,26 @@ where
 /// ```
 #[macro_export]
 macro_rules! fuzz {
-    ( $($x:tt)* ) => { afl::__fuzz!(true, $($x)*) }
+    ( $($x:tt)* ) => { $crate::__fuzz!(true, $($x)*) }
 }
 
 /// Like `fuzz!` above, but panics that are caught inside the fuzzed code are not turned into
 /// crashes.
 #[macro_export]
 macro_rules! fuzz_nohook {
-    ( $($x:tt)* ) => { afl::__fuzz!(false, $($x)*) }
+    ( $($x:tt)* ) => { $crate::__fuzz!(false, $($x)*) }
 }
 
 #[macro_export]
 macro_rules! __fuzz {
     ($hook:expr, |$buf:ident| $body:block) => {
-        afl::fuzz($hook, |$buf| $body);
+        $crate::fuzz($hook, |$buf| $body);
     };
     ($hook:expr, |$buf:ident: &[u8]| $body:block) => {
-        afl::fuzz($hook, |$buf| $body);
+        $crate::fuzz($hook, |$buf| $body);
     };
     ($hook:expr, |$buf:ident: $dty: ty| $body:block) => {
-        afl::fuzz($hook, |$buf| {
+        $crate::fuzz($hook, |$buf| {
             let $buf: $dty = {
                 use arbitrary::{Arbitrary, RingBuffer};
                 if let Ok(d) = RingBuffer::new($buf, $buf.len())


### PR DESCRIPTION
#161 introduced the `__fuzz!` macro, but did not refer to it with a qualified path. Consequently, users of afl.rs were forced to bring `afl::__fuzz` into their namespace, e.g., with `use afl::*`. This PR qualifies the uses of `__fuzz!` so that such a practice is no longer necessary.

For example, the following programs now compile, whereas they wouldn't before:
```rust
fn main() {
    afl::fuzz!(|data: &[u8]| {});
}
```
```rust
use afl::fuzz;

fn main() {
    fuzz!(|data: &[u8]| {});
}
```