### PR TITLE
Use local directories when building for docs.rs

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -32,10 +32,29 @@ fn pkg_version() -> String {
     ret
 }
 
+// Place directories inside the crate when building for docs.rs. 
+// (Modifying system paths are forbidden.)
+
+#[cfg(docsrs)]
+pub fn afl_dir() -> PathBuf {
+    let path = PathBuf::from("./afl");
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+#[cfg(not(docsrs))]
 pub fn afl_dir() -> PathBuf {
     xdg_dir().create_data_directory("afl").unwrap()
 }
 
+#[cfg(docsrs)]
+pub fn afl_llvm_rt_dir() -> PathBuf {
+    let path = PathBuf::from("./afl-llvm-rt");
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+#[cfg(not(docsrs))]
 pub fn afl_llvm_rt_dir() -> PathBuf {
     xdg_dir().create_data_directory("afl-llvm-rt").unwrap()
 }


### PR DESCRIPTION
I haven't tested it, but this code should be enough to get `afl` to compile for docs.rs 

See https://docs.rs/crate/afl/0.10.0/builds/351937 for the current errors. This will require a new release to test.