### PR TITLE
Use arbitrary::Unstructured instead of arbitrary::RingBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "afl"
 version = "0.12.0"
 dependencies = [
+ "arbitrary",
  "cc",
  "clap",
  "lazy_static",
@@ -13,6 +14,15 @@ dependencies = [
  "rustc_version",
  "tempfile",
  "xdg",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510c76ecefdceada737ea728f4f9a84bd2e1ef29f1ba555e560940fe279954de"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -64,6 +74,17 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -168,6 +189,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +256,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "syn"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +294,12 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ xdg = "2.1"
 rustc_version = "0.4"
 
 [dependencies]
+arbitrary = { version = "1", features = ["derive"] }
 cc = "1.0"
 clap = { version = "3.0", features = ["cargo"] }
 libc = "0.2.117"

--- a/examples/arbitrary.rs
+++ b/examples/arbitrary.rs
@@ -1,0 +1,39 @@
+use afl::fuzz;
+use arbitrary::Arbitrary;
+
+#[derive(Arbitrary, Debug, PartialEq, Eq)]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Rgb {
+    pub fn as_hex(&self) -> Hex {
+        let Rgb { r, g, b } = self;
+        Hex(format!("{:02X}{:02X}{:02X}", r, g, b))
+    }
+}
+
+pub struct Hex(String);
+
+impl Hex {
+    fn as_rgb(&self) -> Rgb {
+        let s = self.0.as_str();
+
+        let r = u8::from_str_radix(&s[..2], 16).unwrap();
+        let g = u8::from_str_radix(&s[2..4], 16).unwrap();
+        let b = u8::from_str_radix(&s[4..6], 16).unwrap();
+
+        Rgb { r, g, b }
+    }
+}
+
+pub fn main() {
+    fuzz!(|color: Rgb| {
+        let hex = color.as_hex();
+        let rgb = hex.as_rgb();
+
+        assert_eq!(color, rgb);
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,8 @@ macro_rules! __fuzz {
     ($hook:expr, |$buf:ident: $dty: ty| $body:block) => {
         $crate::fuzz($hook, |$buf| {
             let $buf: $dty = {
-                use arbitrary::{Arbitrary, RingBuffer};
-                if let Ok(d) = RingBuffer::new($buf, $buf.len())
-                    .and_then(|mut b| Arbitrary::arbitrary(&mut b).map_err(|_| ""))
-                {
+                let mut data = ::arbitrary::Unstructured::new($buf);
+                if let Ok(d) = ::arbitrary::Arbitrary::arbitrary(&mut data).map_err(|_| "") {
                     d
                 } else {
                     return;


### PR DESCRIPTION
This PR changes the `fuzz!` macro to generate code that uses `arbitrary::Unstructured` instead of `arbitrary::RingBuffer`, this allows `afl.rs` to work with `arbitrary 1.0`. It also adds an example (which I believe should be built as part of CI) to prevent regressions with the `arbitrary` crate.

Fixes #209