### PR TITLE
Do not write to user data directories on build. Fix docs.rs documentation generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ tempfile = "3"
 
 [features]
 reset_lazy_static = ["lazy_static"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,4 @@ tempfile = "3"
 reset_lazy_static = ["lazy_static"]
 
 [package.metadata.docs.rs]
-all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::{Path, PathBuf};
 
 use xdg;
@@ -15,10 +16,10 @@ fn data_dir(dir_name: &str) -> PathBuf {
     // It is idiomatic to use OUT_DIR in build scripts,
     // and in some environments (e.g., docsrs builds)
     // that may be the only place we can write to.
-    option_env!("OUT_DIR").map_or_else(
-        || xdg_dir().create_data_directory(dir_name).unwrap(),
+    env::var("OUT_DIR").map_or_else(
+        |_| xdg_dir().create_data_directory(dir_name).unwrap(),
         |dir| {
-            let path = Path::new(dir).join(dir_name);
+            let path = Path::new(&dir).join(dir_name);
             std::fs::create_dir_all(&path).unwrap();
             path
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::io::{self, Read};
 use std::panic;
 
 mod common;
+#[doc(hidden)]
 pub use common::*;
 
 // those functions are provided by the afl-llvm-rt static library
@@ -20,6 +21,7 @@ extern "C" {
     static __afl_fuzz_ptr: *const u8;
 }
 
+#[doc(hidden)]
 #[no_mangle]
 pub static __afl_sharedmem_fuzzing: i32 = 1;
 
@@ -147,6 +149,7 @@ macro_rules! fuzz_nohook {
     ( $($x:tt)* ) => { $crate::__fuzz!(false, $($x)*) }
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! __fuzz {
     ($hook:expr, |$buf:ident| $body:block) => {


### PR DESCRIPTION
This change addresses the same problem as #185. It turns out that build scripts are only meant to write to `OUT_DIR`, and in general it is untidy to write things all over the place. docs.rs is specially sensitive to this.

Also, docs.rs does not set the feature flag `docsrs` by itself, but a Cargo package metadata section can be used to instruct docs.rs to pass that flag to Cargo.

I have not tested the change.