### PR TITLE
build.rs: Remove DEBUG environment variable to prevent spurious build…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,9 @@ fn build_afl(out_dir: &Path) {
         .env("NO_BUILD", "1")
         .env("DESTDIR", out_dir)
         .env("PREFIX", "");
+    if std::env::var("DEBUG").as_deref() == Ok("false") {
+        command.env_remove("DEBUG");
+    }
     let status = command.status().expect("could not run 'make'");
     assert!(status.success());
 }


### PR DESCRIPTION
This PR addresses #202.

When running `build.rs`, cargo sets the `DEBUG` environment variable to `true` or `false` depending on the build mode. However, the AFLplusplus makefiles only check if `DEBUG` is set or not. Hence, in either case, AFLplusplus will build in debug mode and append `-Werror` to `CFLAGS`.