### PR TITLE
Add `Update AFLplusplus` workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
   - workflow_dispatch
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: rust-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update_aflplusplus.yml
+++ b/.github/workflows/update_aflplusplus.yml
@@ -1,0 +1,33 @@
+name: Update AFLplusplus
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: update-aflplusplus-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      # smoelius: https://docs.github.com/en/rest/releases/releases#get-the-latest-release
+      - run: |
+          URL='https://api.github.com/repos/AFLplusplus/AFLplusplus/releases/latest'
+          TAG="$(curl -H "Accept: application/vnd.github+json" --silent --show-error "$URL" \
+            | jq -r .tag_name)"
+          cd AFLplusplus
+          git fetch --tags
+          git checkout "$TAG"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update AFLplusplus"
+          token: ${{ secrets.PR_GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow determines the latest release of [AFLpluplus](https://github.com/AFLplusplus/AFLplusplus), and opens a PR to update the git submodule if that release is different than the one currently used.