### PR TITLE
Add panic=abort as default compiler option

### DIFF
--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -376,7 +376,8 @@ where
          -C llvm-args=-sanitizer-coverage-prune-blocks=0 \
          -C opt-level=3 \
          -C target-cpu=native \
-         -C debuginfo=0 ",
+         -C debuginfo=0 \
+         -C panic=abort ",
         passes
     );
 


### PR DESCRIPTION
Hi!
What do you think about adding `-C panic=abort` as default option for building fuzz targets?