### PR TITLE
Add optional feature 'no_cfg_fuzzing'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ tempfile = "3.4"
 
 [features]
 reset_lazy_static = ["lazy_static"]
+no_cfg_fuzzing = []

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -363,8 +363,7 @@ where
     // `-C codegen-units=1` is needed to work around link errors
     // https://github.com/rust-fuzz/afl.rs/pull/193#issuecomment-933550430
     let mut rustflags = format!(
-        "--cfg fuzzing \
-         -C debug-assertions \
+        "-C debug-assertions \
          -C overflow_checks \
          -C passes={passes} \
          -C codegen-units=1 \
@@ -374,6 +373,10 @@ where
          -C opt-level=3 \
          -C target-cpu=native "
     );
+
+    if cfg!(not(feature = "no_cfg_fuzzing")) {
+        rustflags.push_str("--cfg fuzzing ");
+    }
 
     if cfg!(target_os = "linux") {
         // work around https://github.com/rust-fuzz/afl.rs/issues/141 /


### PR DESCRIPTION
This is to allow not setting 'fuzzing' flag when compiling fuzzed targets.
Some crates (eg. secp256k1) stub some functions, when they detect 'fuzzing' flag, which makes them useless when fuzzing.

This is to address issue #305 