### PR TITLE
Add mini CmpLog

### DIFF
--- a/examples/cmplog.rs
+++ b/examples/cmplog.rs
@@ -1,0 +1,31 @@
+fn main() {
+    // This fuzz harness demonstrates the capabilities of CmpLog.
+    // Simply run the fuzzer with the `-c 0` flag and it should find the crash immediately.
+    afl::fuzz!(|data: &[u8]| {
+        if data.len() != 16 {
+            return;
+        }
+        if data[0] != b'A' {
+            return;
+        }
+        if data[1] != b'B' {
+            return;
+        }
+        if data[2] != b'C' {
+            return;
+        }
+        if data[3] != b'D' {
+            return;
+        }
+
+        if data[4..8] != 0x69694141_i32.to_le_bytes() {
+            return;
+        };
+
+        if data[8..12] != *b"1234" || data[12..16] != *b"EFGH" {
+            return;
+        };
+
+        panic!("BOOM");
+    });
+}

--- a/examples/cmplog.rs
+++ b/examples/cmplog.rs
@@ -1,6 +1,6 @@
 fn main() {
     // This fuzz harness demonstrates the capabilities of CmpLog.
-    // Simply run the fuzzer with the `-c 0` flag and it should find the crash immediately.
+    // Simply run the fuzzer and it should find the crash immediately.
     afl::fuzz!(|data: &[u8]| {
         if data.len() != 16 {
             return;

--- a/examples/cmplog.rs
+++ b/examples/cmplog.rs
@@ -18,7 +18,7 @@ fn main() {
             return;
         }
 
-        if data[4..8] != 0x69694141_i32.to_le_bytes() {
+        if data[4..8] != 0x6969_4141_i32.to_le_bytes() {
             return;
         };
 

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -40,22 +40,12 @@ fn main() {
             run_afl(args, "afl-cmin", None);
         }
         Some(("fuzz", sub_matches)) => {
-            let mut args = sub_matches
+            let args = sub_matches
                 .get_many::<OsString>("afl-fuzz args")
                 .unwrap_or_default();
-            // We use next recursively on the args iterator, until we hit "--".
-            // We are then able to append `-c0` to the AFL++ arguments.
-            let mut front_args = vec![];
-            let separator = OsString::from("--");
-            let cmplog_flag = OsString::from("-c0");
-            for next_value in args.by_ref() {
-                if *next_value == separator {
-                    front_args.push(&cmplog_flag);
-                    break;
-                }
-                front_args.push(next_value);
-            }
-            let args = front_args.into_iter().chain(args);
+            // We prepend -c0 to the AFL++ arguments
+            let cmplog_flag = vec![OsString::from("-c0")];
+            let args = cmplog_flag.iter().chain(args);
             let timeout = sub_matches.get_one::<u64>("max_total_time").copied();
             if timeout.is_some() {
                 eprintln!(

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -374,7 +374,6 @@ where
          -C llvm-args=-sanitizer-coverage-trace-pc-guard \
          -C llvm-args=-sanitizer-coverage-prune-blocks=0 \
          -C llvm-args=-sanitizer-coverage-trace-compares \
-         -C llvm-args=-sanitizer-coverage-trace-divs \
          -C opt-level=3 \
          -C target-cpu=native "
     );

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -370,6 +370,8 @@ where
          -C llvm-args=-sanitizer-coverage-level=3 \
          -C llvm-args=-sanitizer-coverage-trace-pc-guard \
          -C llvm-args=-sanitizer-coverage-prune-blocks=0 \
+         -C llvm-args=-sanitizer-coverage-trace-compares \
+         -C llvm-args=-sanitizer-coverage-trace-divs \
          -C opt-level=3 \
          -C target-cpu=native "
     );

--- a/src/bin/cargo-afl.rs
+++ b/src/bin/cargo-afl.rs
@@ -40,9 +40,22 @@ fn main() {
             run_afl(args, "afl-cmin", None);
         }
         Some(("fuzz", sub_matches)) => {
-            let args = sub_matches
+            let mut args = sub_matches
                 .get_many::<OsString>("afl-fuzz args")
                 .unwrap_or_default();
+            // We use next recursively on the args iterator, until we hit "--".
+            // We are then able to append `-c0` to the AFL++ arguments.
+            let mut front_args = vec![];
+            let separator = OsString::from("--");
+            let cmplog_flag = OsString::from("-c0");
+            for next_value in args.by_ref() {
+                if *next_value == separator {
+                    front_args.push(&cmplog_flag);
+                    break;
+                }
+                front_args.push(next_value);
+            }
+            let args = front_args.into_iter().chain(args);
             let timeout = sub_matches.get_one::<u64>("max_total_time").copied();
             if timeout.is_some() {
                 eprintln!(


### PR DESCRIPTION
As suggested in #323, CmpLog could be added to afl.rs to improve effectiveness.

Testing this change on the following example will find the crash **immediately** instead of after a minute.

I can see no performance drop, some more benchmarking might be needed.

You need to specify the `-c 0` option (or `-c path/to/your/binary`).

```rust
fn main() {
    afl::fuzz!(|data: &[u8]| {
        if data.len() != 6 {return}
        if data[0] != b'q' {return}
        if data[1] != b'w' {return}
        if data[2] != b'e' {return}
        if data[3] != b'r' {return}
        if data[4] != b't' {return}
        if data[5] != b'y' {return}
        panic!("BOOM")
    });
}
```

I also tried adding the following flags but they resulted in compilation errors of the target.

```
 -C llvm-args=-sanitizer-coverage-trace-geps \
 -C llvm-args=-sanitizer-coverage-trace-loads \
 -C llvm-args=-sanitizer-coverage-trace-stores \
```