### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "afl"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "arbitrary",
  "home",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-afl"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/afl/Cargo.toml
+++ b/afl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "afl"
-version = "0.14.0"
+version = "0.14.1"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [

--- a/cargo-afl/Cargo.toml
+++ b/cargo-afl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-afl"
-version = "0.14.0"
+version = "0.14.1"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
Version 0.14.0 failed to include the AFLplusplus submodule.