### PR TITLE
Add plugins feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,13 @@ jobs:
       matrix:
         environment: [ubuntu-latest, macos-latest]
         toolchain: [stable, nightly]
+        features: [default, plugins]
         cc: [cc, clang]
+        exclude:
+          - environment: macos-latest
+            features: plugins
+          - toolchain: stable
+            features: plugins
         include:
           - cc: cc
             cxx: c++
@@ -45,21 +51,37 @@ jobs:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
     steps:
-      - if: ${{ matrix.environment == 'ubuntu-latest' }}
-        run: sudo apt-get install llvm
       - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Rustup
         run: rustup default ${{ matrix.toolchain }}
+      - name: Install LLVM
+        id: install-llvm
+        run: |
+          LLVM_VERSION="$(rustc --version -v | grep '^LLVM version:' | grep -o '[0-9]\+' | head -n 1)"
+          if [[ ${{ matrix.environment  }} = 'macos-latest' ]]; then
+            brew update
+            brew install llvm@"$LLVM_VERSION" || true
+            echo "PATH=/usr/local/opt/llvm/bin:$PATH" >> "$GITHUB_OUTPUT"
+          else
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            sudo ./llvm.sh "$LLVM_VERSION"
+            echo "PATH=$PATH" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       - name: Build
-        run: cargo build -vv
+        run: cargo build --features=${{ matrix.features }} -vv
+        env:
+          PATH: ${{ steps.install-llvm.outputs.path }}
       - name: Run afl-system-config
-        run: cargo run -- afl system-config
+        run: cargo run --features=${{ matrix.features }} -- afl system-config
       - name: Build examples (with AFL instrumentation)
-        run: cargo run -- afl build --examples -vv
+        run: cargo run --features=${{ matrix.features }} -- afl build --examples -vv
       - name: Run tests
-        run: cargo test -p cargo-afl -vv
+        run: cargo test --features=${{ matrix.features }} -p cargo-afl -vv
   all-checks:
     needs: [lint, build]
     runs-on: ubuntu-latest

--- a/afl/examples/cmplog.rs
+++ b/afl/examples/cmplog.rs
@@ -2,7 +2,7 @@ fn main() {
     // This fuzz harness demonstrates the capabilities of CmpLog.
     // Simply run the fuzzer and it should find the crash immediately.
     afl::fuzz!(|data: &[u8]| {
-        if data.len() != 16 {
+        if data.len() < 29 {
             return;
         }
         if data[0] != b'A' {
@@ -25,6 +25,13 @@ fn main() {
         if data[8..12] != *b"1234" || data[12..16] != *b"EFGH" {
             return;
         };
+
+        let slice = &data[16..];
+        let match_string = "Hello, world!";
+        let compare_string = String::from_utf8(slice.to_vec()).unwrap_or_default();
+        if compare_string != match_string {
+            return;
+        }
 
         panic!("BOOM");
     });

--- a/cargo-afl/Cargo.toml
+++ b/cargo-afl/Cargo.toml
@@ -32,3 +32,7 @@ assert_cmd = "2.0"
 ctor = "0.2"
 predicates = "3.0"
 tempfile = "3.8"
+
+[features]
+default = []
+plugins = []

--- a/cargo-afl/src/common.rs
+++ b/cargo-afl/src/common.rs
@@ -57,18 +57,18 @@ pub fn afl_dir(base: Option<&Path>) -> PathBuf {
 
 #[allow(dead_code)]
 #[must_use]
-pub fn afl_llvm_rt_dir(base: Option<&Path>) -> PathBuf {
-    data_dir(base, "afl-llvm-rt")
+pub fn afl_llvm_dir(base: Option<&Path>) -> PathBuf {
+    data_dir(base, "afl-llvm")
 }
 
 #[allow(dead_code)]
 #[must_use]
 pub fn object_file_path(base: Option<&Path>) -> PathBuf {
-    afl_llvm_rt_dir(base).join("libafl-llvm-rt.o")
+    afl_llvm_dir(base).join("libafl-llvm-rt.o")
 }
 
 #[allow(dead_code)]
 #[must_use]
 pub fn archive_file_path(base: Option<&Path>) -> PathBuf {
-    afl_llvm_rt_dir(base).join("libafl-llvm-rt.a")
+    afl_llvm_dir(base).join("libafl-llvm-rt.a")
 }


### PR DESCRIPTION
This PR activates full cmplog by compiling the afl++ llvm plugins and linking them into the target binaries.
This is activated via an added features "cmplog" as it needs nightly and llvm tools. It is not activated by default.

This fixes #323 .