### PR TITLE
Fix running AFL with no 'fuzzing' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ So if you run multiple AFL++ instances on your fuzzing target, you can disable C
 This [document](https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/fuzzing_in_depth.md)
 will familiarize you with AFL++ features to help in running a successful fuzzing campaign.
 
-By default, 'fuzzing' config is set when `cargo-afl` is used to build. If you want to prevent this, just set 'AFL_NO_CFG_FUZZING=1`
-environmental variable, when building.
+By default, 'fuzzing' config is set when `cargo-afl` is used to build. If you want to prevent this, just set the
+environment variable `AFL_NO_CFG_FUZZING` to `1` when building.
 
 [conditional compilation]: https://doc.rust-lang.org/reference.html#conditional-compilation
 [Cargo feature]: http://doc.crates.io/manifest.html#the-[features]-section

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ So if you run multiple AFL++ instances on your fuzzing target, you can disable C
 This [document](https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/fuzzing_in_depth.md)
 will familiarize you with AFL++ features to help in running a successful fuzzing campaign.
 
+By default, 'fuzzing' config is set when `cargo-afl` is used to build. If you want to prevent this, just set 'AFL_NO_CFG_FUZZING=1`
+environmental variable, when building.
+
 [conditional compilation]: https://doc.rust-lang.org/reference.html#conditional-compilation
 [Cargo feature]: http://doc.crates.io/manifest.html#the-[features]-section
 [example-defer]: https://github.com/frewsxcv/afl.rs/blob/master/examples/deferred-init.rs

--- a/afl/build.rs
+++ b/afl/build.rs
@@ -8,7 +8,9 @@ fn main() {
         || env::var("TESTING_BUILD").is_ok();
 
     let cfg_fuzzing = env::var("CARGO_CFG_FUZZING").is_ok();
-    let no_cfg_fuzzing = !env::var("AFL_NO_CFG_FUZZING").unwrap_or_default().is_empty();
+    let no_cfg_fuzzing = !env::var("AFL_NO_CFG_FUZZING")
+        .unwrap_or_default()
+        .is_empty();
 
     // afl-fuzz is sensitive to AFL_ env variables. Let's remove this particular one - it did it's job
     env::remove_var("AFL_NO_CFG_FUZZING");

--- a/afl/build.rs
+++ b/afl/build.rs
@@ -8,10 +8,12 @@ fn main() {
         || env::var("TESTING_BUILD").is_ok();
 
     let cfg_fuzzing = env::var("CARGO_CFG_FUZZING").is_ok();
+    let no_cfg_fuzzing = !env::var("AFL_NO_CFG_FUZZING").unwrap_or_default().is_empty();
 
-    let feature_no_fuzzing = env::var("CARGO_FEATURE_NO_FUZZING").is_ok();
+    // afl-fuzz is sensitive to AFL_ env variables. Let's remove this particular one - it did it's job
+    env::remove_var("AFL_NO_CFG_FUZZING");
 
-    if building_in_cargo_home && !cfg_fuzzing && !feature_no_fuzzing {
+    if building_in_cargo_home && !cfg_fuzzing && !no_cfg_fuzzing {
         println!("cargo:warning=You appear to be building `afl` not under `cargo-afl`.");
         println!("cargo:warning=Perhaps you used `cargo build` instead of `cargo afl build`?");
     }

--- a/afl/build.rs
+++ b/afl/build.rs
@@ -8,14 +8,11 @@ fn main() {
         || env::var("TESTING_BUILD").is_ok();
 
     let cfg_fuzzing = env::var("CARGO_CFG_FUZZING").is_ok();
-    let no_cfg_fuzzing = !env::var("AFL_NO_CFG_FUZZING")
-        .unwrap_or_default()
-        .is_empty();
+    let cfg_no_fuzzing = env::var("CARGO_CFG_NO_FUZZING").is_ok();
 
-    // afl-fuzz is sensitive to AFL_ env variables. Let's remove this particular one - it did it's job
-    env::remove_var("AFL_NO_CFG_FUZZING");
-
-    if building_in_cargo_home && !cfg_fuzzing && !no_cfg_fuzzing {
+    println!("cfg_fuzzing = {:?} ", cfg_fuzzing);
+    println!("cfg_no_fuzzing = {:?} ", cfg_no_fuzzing);
+    if building_in_cargo_home && !cfg_fuzzing && !cfg_no_fuzzing {
         println!("cargo:warning=You appear to be building `afl` not under `cargo-afl`.");
         println!("cargo:warning=Perhaps you used `cargo build` instead of `cargo afl build`?");
     }

--- a/afl/build.rs
+++ b/afl/build.rs
@@ -10,8 +10,6 @@ fn main() {
     let cfg_fuzzing = env::var("CARGO_CFG_FUZZING").is_ok();
     let cfg_no_fuzzing = env::var("CARGO_CFG_NO_FUZZING").is_ok();
 
-    println!("cfg_fuzzing = {:?} ", cfg_fuzzing);
-    println!("cfg_no_fuzzing = {:?} ", cfg_no_fuzzing);
     if building_in_cargo_home && !cfg_fuzzing && !cfg_no_fuzzing {
         println!("cargo:warning=You appear to be building `afl` not under `cargo-afl`.");
         println!("cargo:warning=Perhaps you used `cargo build` instead of `cargo afl build`?");

--- a/cargo-afl/src/bin/cargo-afl.rs
+++ b/cargo-afl/src/bin/cargo-afl.rs
@@ -310,7 +310,8 @@ where
          -C target-cpu=native "
     );
 
-    if cfg!(not(feature = "no_cfg_fuzzing")) {
+    let no_cfg_fuzzing = env::var("AFL_NO_CFG_FUZZING").unwrap_or_default();
+    if no_cfg_fuzzing.is_empty() {
         rustflags.push_str("--cfg fuzzing ");
     }
 
@@ -343,6 +344,7 @@ where
         .env("RUSTDOCFLAGS", &rustdocflags)
         .env("ASAN_OPTIONS", asan_options)
         .env("TSAN_OPTIONS", tsan_options)
+        .env("AFL_NO_CFG_FUZZING", no_cfg_fuzzing)
         .status()
         .unwrap();
     process::exit(status.code().unwrap_or(1));


### PR DESCRIPTION
This is to address issue https://github.com/rust-fuzz/afl.rs/issues/397

In order to prevent `cargo-afl` from setting `fuzzing` flag one needs to set `AFL_NO_CFG_FUZZING` environmental variable.
Eg.
```
 AFL_NO_CFG_FUZZING=1 cargo afl build 
 ```
