### PR TITLE
Reintroduce `NO_BUILD=1`

### DIFF
--- a/cargo-afl/build.rs
+++ b/cargo-afl/build.rs
@@ -75,7 +75,6 @@ fn build_afl(work_dir: &Path, base: Option<&Path>) {
         .args(["clean", "install"])
         // skip the checks for the legacy x86 afl-gcc compiler
         .env("AFL_NO_X86", "1")
-        // build just the runtime to avoid troubles with Xcode clang on macOS
         .env("DESTDIR", common::afl_dir(base))
         .env("PREFIX", "")
         .env_remove("DEBUG");
@@ -83,6 +82,10 @@ fn build_afl(work_dir: &Path, base: Option<&Path>) {
     if cfg!(feature = "plugins") {
         let llvm_config = check_llvm_and_get_config();
         command.env("LLVM_CONFIG", llvm_config);
+    } else {
+        // build just the runtime to avoid troubles with Xcode clang on macOS
+        // smoelius: `NO_BUILD=1` also makes `cargo build` significantly faster.
+        command.env("NO_BUILD", "1");
     }
 
     let status = command


### PR DESCRIPTION
Version 0.14.5 removed this setting ([here](
https://github.com/rust-fuzz/afl.rs/commit/785db302eedda71b9702bdc2d63eb824ba529991#diff-2d8fbbc60fb70d8a96ce3da99b3d4b4499282482677ed0c50fd13f792cbf5af4R78) and [here](
https://github.com/rust-fuzz/afl.rs/commit/ce3397f4cc6207dedd217f10febb25f5cd9c0f68#diff-2d8fbbc60fb70d8a96ce3da99b3d4b4499282482677ed0c50fd13f792cbf5af4L78)), which significantly increased build times.

This PR reintroduces the setting when the `plugins` feature is not enabled.