### PR TITLE
Correct logic in `all-checks`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,5 +85,8 @@ jobs:
   all-checks:
     needs: [lint, build]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
-      - run: true
+      - name: Check results
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
From [Defining prerequisite jobs](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs):
> If you would like a job to run even if a job it is dependent on did not succeed, use the `always()` conditional expression in `jobs.<job_id>.if`.