### PR TITLE
Allow setting `__afl_persistent_loop` argument (support for #433)

### DIFF
--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -8,7 +8,6 @@
 use std::env;
 use std::io::{self, Read};
 use std::panic;
-use std::u32;
 
 // those functions are provided by the afl-llvm-rt static library
 extern "C" {

--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -75,7 +75,7 @@ where
             .expect("Failed to parse environment variable to a number")
     } else {
         usize::MAX
-    };      
+    };
 
     // initialize forkserver there
     unsafe { __afl_manual_init() };

--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -70,15 +70,15 @@ where
 
     let mut input = vec![];
 
-    let loop_count: u32 = env::var("AFL_FUZZER_LOOPCOUNT")
-        .unwrap_or_else(|_| "4294967295".to_string())
-        .parse()
-        .unwrap_or(u32::MAX);
+    let loop_count: usize = env::var("AFL_FUZZER_LOOPCOUNT")
+        .unwrap_or_else(|_| u32::MAX.to_string())
+        .parse::<usize>()
+        .expect("Failed to parse environment variable to a number");
 
     // initialize forkserver there
     unsafe { __afl_manual_init() };
 
-    while unsafe { __afl_persistent_loop(loop_count as usize) } != 0 {
+    while unsafe { __afl_persistent_loop(loop_count) } != 0 {
         // get the testcase from the fuzzer
         let input_ref = if unsafe { __afl_fuzz_ptr.is_null() } {
             // in-memory testcase delivery is not enabled

--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -5,8 +5,10 @@
 // you may not use this file except in compliance with the License.
 // See `LICENSE` in this repository.
 
+use std::env;
 use std::io::{self, Read};
 use std::panic;
+use std::u32;
 
 // those functions are provided by the afl-llvm-rt static library
 extern "C" {
@@ -68,10 +70,15 @@ where
 
     let mut input = vec![];
 
+    let loop_count: u32 = env::var("AFL_FUZZER_LOOPCOUNT")
+        .unwrap_or_else(|_| "4294967295".to_string())
+        .parse()
+        .unwrap_or(u32::MAX);
+
     // initialize forkserver there
     unsafe { __afl_manual_init() };
 
-    while unsafe { __afl_persistent_loop(1000) } != 0 {
+    while unsafe { __afl_persistent_loop(loop_count as usize) } != 0 {
         // get the testcase from the fuzzer
         let input_ref = if unsafe { __afl_fuzz_ptr.is_null() } {
             // in-memory testcase delivery is not enabled

--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -70,10 +70,13 @@ where
 
     let mut input = vec![];
 
-    let loop_count: usize = env::var("AFL_FUZZER_LOOPCOUNT")
-        .unwrap_or_else(|_| u32::MAX.to_string())
-        .parse::<usize>()
-        .expect("Failed to parse environment variable to a number");
+    let loop_count = if let Ok(value) = env::var("AFL_FUZZER_LOOPCOUNT") {
+        value
+            .parse()
+            .expect("Failed to parse environment variable to a number")
+    } else {
+        usize::MAX
+    };      
 
     // initialize forkserver there
     unsafe { __afl_manual_init() };


### PR DESCRIPTION
#433 
