### PR TITLE
Do not pass `-C passes=...` when nightly is used and plugins are compiled

### DIFF
--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -252,7 +252,7 @@ where
     environment_variables.insert("ASAN_OPTIONS", asan_options);
     environment_variables.insert("TSAN_OPTIONS", tsan_options);
 
-    if plugins_available() && is_nightly() {
+    if plugins_available() {
         // Make sure we are on nightly for the -Z flags
         assert!(
             rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly,

--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -241,12 +241,12 @@ where
     let binding = common::afl_llvm_dir();
     let p = binding.display();
 
-    let mut rustflags = format!(
+    let mut rustflags = String::from(
         "-C debug-assertions \
              -C overflow_checks \
              -C codegen-units=1 \
              -C opt-level=3 \
-             -C target-cpu=native "
+             -C target-cpu=native ",
     );
     let mut environment_variables = HashMap::<&str, String>::new();
     environment_variables.insert("ASAN_OPTIONS", asan_options);


### PR DESCRIPTION
**Bug 1**

This PR fixes just the major issue: when nightly is used and plugins are compiled - then still the default bad sancov of LLVM is used, because -C sancov is always passed.

_I sadly have no time to fix the other two bugs, too time constraint :(_


**Bug 2**
Another issue I found and not fixed in this PR:
AFL++'s LLVM plugins are not built by default.

And even if the user wants to build them the check is faulty:
```
$ cargo-afl afl config --plugins
AFL LLVM runtime was already built for Rust rustc-1.75.0-nightly-42b1224; run `cargo afl config --build --force` to rebuild it.
$ ls /home/marc/.local/share/afl.rs/rustc-1.75.0-nightly-42b1224/afl.rs-0.15.1/afl-llvm
libafl-llvm-rt.a  libafl-llvm-rt.o
```
The message says "runtime" which would be correct, because the runtime is there, but what we want are the `--plugins` which are not.

As a workaround `--force` can be added which will enforce building the plugins.


**Bug 3**
And finally: there is not way for a user to see if AFL++'s plugins will be used or not. My original change to the version command made this visible, now the only way to see it to use `-vv` while builind a target.