### PR TITLE
Use `expr` metavariable in `fuzz!` macro

### DIFF
--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -153,13 +153,13 @@ macro_rules! fuzz_nohook {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __fuzz {
-    ($hook:expr, |$buf:ident| $body:block) => {
+    ($hook:expr, |$buf:ident| $body:expr) => {
         $crate::fuzz($hook, |$buf| $body);
     };
-    ($hook:expr, |$buf:ident: &[u8]| $body:block) => {
+    ($hook:expr, |$buf:ident: &[u8]| $body:expr) => {
         $crate::fuzz($hook, |$buf| $body);
     };
-    ($hook:expr, |$buf:ident: $dty: ty| $body:block) => {
+    ($hook:expr, |$buf:ident: $dty: ty| $body:expr) => {
         $crate::fuzz($hook, |$buf| {
             let $buf: $dty = {
                 let mut data = ::arbitrary::Unstructured::new($buf);


### PR DESCRIPTION
This allows expressions not wrapped in curly brackets, which is useful when e.g. calling out to another function:
```rust
fn fuzz_with(data: &[u8]) {
    // Do fuzzing
}

fn main() {
    fuzz!(|data| fuzz_with(data));
}
```