### PR TITLE
Temporarily add `ubuntu-24.04` as a target, and remove `ubuntu-latest`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,10 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        environment: [ubuntu-latest, macos-latest]
+        # smoelius: Temporarily add `ubuntu-24.04` as a target, and remove `ubuntu-latest`, until
+        # the following issue is resolved: https://github.com/llvm/llvm-project/issues/99502
+        # environment: [ubuntu-latest, macos-latest]
+        environment: [ubuntu-24.04, macos-latest]
         toolchain: [stable, nightly]
         plugins: [true, false]
         cc: [cc, clang]


### PR DESCRIPTION
See: https://github.com/llvm/llvm-project/issues/99502