### PR TITLE
Change `publish` test to `package` test

### DIFF
--- a/cargo-afl/tests/crates_io.rs
+++ b/cargo-afl/tests/crates_io.rs
@@ -153,10 +153,10 @@ fn cargo_afl_build_command(home: &Path, cargo_afl: &Path) -> Command {
 }
 
 #[test]
-fn publish() {
+fn package() {
     for subdir in ["afl", "cargo-afl"] {
         Command::new("cargo")
-            .args(["publish", "--allow-dirty", "--dry-run"])
+            .args(["package", "--allow-dirty"])
             .current_dir(Path::new("..").join(subdir))
             .assert()
             .success();


### PR DESCRIPTION
When run with the nightly toolchain, the `publish` test recently started failing with the following:
```
error: crate afl@0.15.10 already exists on crates.io index
```
I think this is the cause: https://github.com/rust-lang/cargo/blob/6ede1e2b276eaf93618765a08bd3ec2f0f44d955/src/cargo/ops/registry/publish.rs#L136

See, for example: https://github.com/rust-lang/cargo/pull/14550/files#r1763454347