### PR TITLE
introduce AFLRS_REQUIRE_PLUGINS & AFL_OPT_LEVEL

### DIFF
--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -303,7 +303,7 @@ where
         if require_plugins {
             assert!(
                 has_plugins,
-                "AFL++ plugins are not available, run cargo afl config --force --plugins"
+                "AFL++ plugins are not available; run `cargo afl config --build --force --plugins`"
             );
         }
 


### PR DESCRIPTION
``rustc`` will complain if an invalid ``opt-level`` is provided so we don't really need to check the value, IMO