### PR TITLE
Remove Ubuntu 24.04 environment

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        environment: [ubuntu-latest, ubuntu-24.04, macos-latest]
+        environment: [ubuntu-latest, macos-latest]
         toolchain: [stable, nightly]
         plugins: [true, false]
         cc: [cc, clang]


### PR DESCRIPTION
`ubuntu-latest` is Ubuntu 24.04 now.