### PR TITLE
Add split-switches-pass to AFL++ instrumentation

### DIFF
--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -308,12 +308,12 @@ where
         }
 
         rustflags.push_str(&format!(
-            "-Z llvm-plugins={p}/cmplog-instructions-pass.so  \
-            -Z llvm-plugins={p}/cmplog-routines-pass.so \
+            "-Z llvm-plugins={p}/afl-llvm-dict2file.so \
             -Z llvm-plugins={p}/cmplog-switches-pass.so \
+            -Z llvm-plugins={p}/split-switches-pass.so \
             -Z llvm-plugins={p}/SanitizerCoveragePCGUARD.so \
-            -Z llvm-plugins={p}/afl-llvm-dict2file.so
-            "
+            -Z llvm-plugins={p}/cmplog-instructions-pass.so  \
+            -Z llvm-plugins={p}/cmplog-routines-pass.so"
         ));
 
         environment_variables.insert("AFL_QUIET", "1".to_string());

--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -313,7 +313,8 @@ where
             -Z llvm-plugins={p}/split-switches-pass.so \
             -Z llvm-plugins={p}/SanitizerCoveragePCGUARD.so \
             -Z llvm-plugins={p}/cmplog-instructions-pass.so  \
-            -Z llvm-plugins={p}/cmplog-routines-pass.so"
+            -Z llvm-plugins={p}/cmplog-routines-pass.so \
+            "
         ));
 
         environment_variables.insert("AFL_QUIET", "1".to_string());


### PR DESCRIPTION
the ``split-switches-pass`` was missing for AFL++'s cmplog instrumentation. And also, the order of the passes matters so I re-ordered them in the same order as AFL++'s ``afl-cc.c``