### PR TITLE
Allowing the `unexpected_cfgs` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,9 @@ members = ["afl", "cargo-afl"]
 resolver = "2"
 
 [workspace.lints.rust.unexpected_cfgs]
-level = "deny"
+# smoelius: Temporarily setting the lint level to `allow`.
+# level = "deny"
+level = "allow"
 check-cfg = ["cfg(fuzzing)"]
 
 [workspace.lints.clippy]


### PR DESCRIPTION
This recent change is causing CI to fail: https://github.com/rust-lang/rust/pull/132577

The failure is caused by the `used_linker` feature in code produced by the `ctor::ctor` attribute macro.