### PR TITLE
Revert "Allowing the `unexpected_cfgs` lint"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "ctor"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,7 @@ members = ["afl", "cargo-afl"]
 resolver = "2"
 
 [workspace.lints.rust.unexpected_cfgs]
-# smoelius: Temporarily setting the lint level to `allow`.
-# level = "deny"
-level = "allow"
+level = "deny"
 check-cfg = ["cfg(fuzzing)"]
 
 [workspace.lints.clippy]


### PR DESCRIPTION
Reverts rust-fuzz/afl.rs#556