### PR TITLE
Eliminate use of gold linker

### DIFF
--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -338,13 +338,6 @@ where
         rustflags.push_str("--cfg fuzzing ");
     }
 
-    if cfg!(target_os = "linux") {
-        // work around https://github.com/rust-fuzz/afl.rs/issues/141 /
-        // https://github.com/rust-lang/rust/issues/53945, can be removed once
-        // those are fixed.
-        rustflags.push_str("-Clink-arg=-fuse-ld=gold ");
-    }
-
     // RUSTFLAGS are not used by rustdoc, instead RUSTDOCFLAGS are used. Since
     // doctests will try to link against afl-llvm-rt, set up RUSTDOCFLAGS to
     // have doctests built the same as other code to avoid issues with doctests.


### PR DESCRIPTION
If I am tracking the history right, use of the gold linker was added in this PR: https://github.com/rust-fuzz/afl.rs/pull/144

However, nightly rust has started passing `"-Wl,-znostart-stop-gc"`, and gold doesn't recognize that option:
```
+  = note: /usr/bin/ld.gold: nostart-stop-gc: unknown -z option
```
See: https://github.com/rust-lang/rust/pull/137685