### PR TITLE
Enable LTO and strip symbols for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ pedantic = { level = "warn", priority = -1 }
 disallowed-macros = "allow"
 format-push-string = "allow"
 missing-panics-doc = "allow"
+
+[profile.release]
+lto = "fat"
+strip = "symbols"
+codegen-units = 1


### PR DESCRIPTION
Decreases file size of `cargo-afl` from 1.5MB down to 1017KB.