### PR TITLE
Remove `#[allow(dead_code)]` attributes from common.rs

### DIFF
--- a/cargo-afl/src/common.rs
+++ b/cargo-afl/src/common.rs
@@ -50,27 +50,22 @@ fn pkg_version() -> String {
     ret
 }
 
-#[allow(dead_code)]
 pub fn afl_dir() -> Result<PathBuf> {
     data_dir("afl")
 }
 
-#[allow(dead_code)]
 pub fn afl_llvm_dir() -> Result<PathBuf> {
     data_dir("afl-llvm")
 }
 
-#[allow(dead_code)]
 pub fn object_file_path() -> Result<PathBuf> {
     afl_llvm_dir().map(|path| path.join("libafl-llvm-rt.o"))
 }
 
-#[allow(dead_code)]
 pub fn archive_file_path() -> Result<PathBuf> {
     afl_llvm_dir().map(|path| path.join("libafl-llvm-rt.a"))
 }
 
-#[allow(dead_code)]
 pub fn plugins_available() -> Result<bool> {
     let afl_llvm_dir = afl_llvm_dir()?;
     for result in afl_llvm_dir


### PR DESCRIPTION
These used to be required because of how the module is used by build.rs: https://github.com/rust-fuzz/afl.rs/blob/b1fd2a5eba64a03f03359334aa67c72ef61cab0a/cargo-afl/build.rs#L4-L5

However, Rust no longer seems to warn about them. I'm not sure why.