### PR TITLE
Pin to nightly-2026-01-28

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,8 +41,8 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        environment: [ubuntu-latest, ubuntu-24.04, macos-latest]
-        toolchain: [stable, nightly]
+        environment: [ubuntu-latest, macos-latest]
+        toolchain: [stable, nightly-2026-01-28]
         plugins: [true, false]
         cc: [cc, clang]
         exclude:


### PR DESCRIPTION
From what I can tell, LLVM 22 is not released yet: https://github.com/rust-lang/rust/pull/150722

I think that is why the LLVM 22 packages cannot be installed.

Also, remove ubuntu-24.04 as a testing environment.