### PR TITLE
Add afl_init!() macro for custom harnesses

### DIFF
--- a/afl/examples/custom_harness.rs
+++ b/afl/examples/custom_harness.rs
@@ -1,0 +1,12 @@
+use std::io::Read;
+
+fn main() {
+    afl::afl_init!();
+
+    let mut input = Vec::new();
+    std::io::stdin().read_to_end(&mut input).unwrap();
+
+    if input.len() > 3 && input[0] == b'X' {
+        panic!("found a bug!");
+    }
+}

--- a/afl/examples/custom_harness.rs
+++ b/afl/examples/custom_harness.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::manual_assert)]
+
 use std::io::Read;
 
 fn main() {

--- a/afl/src/lib.rs
+++ b/afl/src/lib.rs
@@ -217,6 +217,34 @@ macro_rules! ijon_stack_min {
 
 // end if AFL++ IJON functions
 
+/// Embeds AFL++ marker strings into the binary so that AFL++ detects
+/// persistent mode and deferred forkserver mode.
+///
+/// This is called automatically by [`fuzz!`]. You only need to call this
+/// directly if you are writing a custom harness that does not use `fuzz!`.
+///
+/// ```rust,no_run
+/// use std::io::Read;
+///
+/// fn main() {
+///     afl::afl_init!();
+///
+///     let mut input = Vec::new();
+///     std::io::stdin().read_to_end(&mut input).unwrap();
+///     // test logic here
+/// }
+/// ```
+#[macro_export]
+macro_rules! afl_init {
+    () => {
+        static _AFL_PERSIST_MARKER: &str = "##SIG_AFL_PERSISTENT##\0";
+        static _AFL_DEFER_MARKER: &str = "##SIG_AFL_DEFER_FORKSRV##\0";
+
+        unsafe { ::std::ptr::read_volatile(&raw const _AFL_PERSIST_MARKER) };
+        unsafe { ::std::ptr::read_volatile(&raw const _AFL_DEFER_MARKER) };
+    };
+}
+
 #[allow(non_upper_case_globals)]
 #[doc(hidden)]
 #[unsafe(no_mangle)]
@@ -276,17 +304,7 @@ where
     F: FnMut(&[u8]) + std::panic::RefUnwindSafe,
     R: FnMut(),
 {
-    // this marker strings needs to be in the produced executable for
-    // afl-fuzz to detect `persistent mode` and `defered mode`
-    static PERSIST_MARKER: &str = "##SIG_AFL_PERSISTENT##\0";
-    static DEFERED_MARKER: &str = "##SIG_AFL_DEFER_FORKSRV##\0";
-
-    // we now need a fake instruction to prevent the compiler from optimizing out
-    // those marker strings
-    unsafe { std::ptr::read_volatile(&raw const PERSIST_MARKER) }; // hack used in https://github.com/bluss/bencher for black_box()
-    unsafe { std::ptr::read_volatile(&raw const DEFERED_MARKER) };
-    // unsafe { asm!("" : : "r"(&PERSIST_MARKER)) }; // hack used in nightly's back_box(), requires feature asm
-    // unsafe { asm!("" : : "r"(&DEFERED_MARKER)) };
+    afl_init!();
 
     if hook {
         let prev_hook = std::panic::take_hook();


### PR DESCRIPTION
## Summary
- Adds a public `afl_init!()` macro that embeds AFL++ persistent mode and deferred forkserver marker strings into a binary without requiring the `fuzz!` macro
- Refactors `fuzz_with_reset()` to use `afl_init!()` internally, keeping the marker strings defined in one place
- Adds a `custom_harness` example showing usage

## Test plan
- [x] `cargo check -p afl` passes
- [ ] Verify marker strings appear in a binary that calls `afl_init!()` but not `fuzz!()`
- [ ] Verify `cargo afl fuzz` correctly detects persistent/deferred mode with a custom harness using `afl_init!()`

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)