### PR TITLE
Add option to omit CmpLog instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ By default, the AFL++ [CMPLOG](https://github.com/AFLplusplus/AFLplusplus/blob/s
 feature is activated, which helps to achieve good code coverage.
 However, it is not beneficial to activate CMPLOG on more than two instances.
 So if you run multiple AFL++ instances on your fuzzing target, you can disable CMPLOG by specifying the command line parameter '-c -'.
+To omit CMPLOG instrumentation from the built target entirely, set the environment variable
+`AFLRS_NO_CMPLOG` to `1` when building.
 
 This [document](https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/fuzzing_in_depth.md)
 will familiarize you with AFL++ features to help in running a successful fuzzing campaign.

--- a/cargo-afl/src/main.rs
+++ b/cargo-afl/src/main.rs
@@ -3,6 +3,7 @@ use clap::{CommandFactory, FromArgMatches, Parser, crate_version};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::path::Path;
 use std::process::{self, Command, Stdio};
 
 const HELP: &str = "In addition to the subcommands above, Cargo subcommands are also \
@@ -277,7 +278,6 @@ where
     // https://github.com/rust-fuzz/afl.rs/pull/193#issuecomment-933550430
 
     let binding = common::afl_llvm_dir().unwrap();
-    let p = binding.display();
 
     let mut rustflags = format!(
         "-C debug-assertions \
@@ -305,16 +305,8 @@ where
             );
         }
 
-        rustflags.push_str(&format!(
-            "-Z llvm-plugins={p}/afl-llvm-dict2file.so \
-            -Z llvm-plugins={p}/cmplog-switches-pass.so \
-            -Z llvm-plugins={p}/split-switches-pass.so \
-            -Z llvm-plugins={p}/SanitizerCoveragePCGUARD.so \
-            -Z llvm-plugins={p}/cmplog-instructions-pass.so  \
-            -Z llvm-plugins={p}/cmplog-routines-pass.so \
-            -Z llvm-plugins={p}/afl-llvm-ijon-pass.so
-            "
-        ));
+        let cmplog_enabled = env::var("AFLRS_NO_CMPLOG").is_err();
+        rustflags.push_str(&llvm_plugin_rustflags(&binding, cmplog_enabled));
 
         environment_variables.insert("AFL_QUIET", "1".to_string());
     } else {
@@ -362,6 +354,30 @@ where
         .status()
         .unwrap();
     process::exit(status.code().unwrap_or(1));
+}
+
+fn llvm_plugin_rustflags(plugin_dir: &Path, cmplog_enabled: bool) -> String {
+    let mut passes = vec!["afl-llvm-dict2file.so"];
+
+    if cmplog_enabled {
+        passes.push("cmplog-switches-pass.so");
+    }
+
+    passes.extend(["split-switches-pass.so", "SanitizerCoveragePCGUARD.so"]);
+
+    if cmplog_enabled {
+        passes.extend(["cmplog-instructions-pass.so", "cmplog-routines-pass.so"]);
+    }
+
+    passes.push("afl-llvm-ijon-pass.so");
+
+    let mut rustflags = String::new();
+    for pass in passes {
+        rustflags.push_str("-Z llvm-plugins=");
+        rustflags.push_str(&plugin_dir.join(pass).display().to_string());
+        rustflags.push(' ');
+    }
+    rustflags
 }
 
 fn is_nightly() -> bool {
@@ -441,5 +457,28 @@ mod tests {
     #[test]
     fn invalid_utf8_is_invalid() {
         assert!(String::from_utf8(invalid_utf8().into_vec()).is_err());
+    }
+
+    #[test]
+    fn llvm_plugin_rustflags_include_cmplog_by_default() {
+        let rustflags = llvm_plugin_rustflags(Path::new("/afl-llvm"), true);
+
+        assert!(rustflags.contains("/afl-llvm/afl-llvm-dict2file.so"));
+        assert!(rustflags.contains("/afl-llvm/cmplog-switches-pass.so"));
+        assert!(rustflags.contains("/afl-llvm/cmplog-instructions-pass.so"));
+        assert!(rustflags.contains("/afl-llvm/cmplog-routines-pass.so"));
+        assert!(rustflags.contains("/afl-llvm/SanitizerCoveragePCGUARD.so"));
+    }
+
+    #[test]
+    fn llvm_plugin_rustflags_can_omit_cmplog() {
+        let rustflags = llvm_plugin_rustflags(Path::new("/afl-llvm"), false);
+
+        assert!(rustflags.contains("/afl-llvm/afl-llvm-dict2file.so"));
+        assert!(!rustflags.contains("cmplog-switches-pass.so"));
+        assert!(!rustflags.contains("cmplog-instructions-pass.so"));
+        assert!(!rustflags.contains("cmplog-routines-pass.so"));
+        assert!(rustflags.contains("/afl-llvm/SanitizerCoveragePCGUARD.so"));
+        assert!(rustflags.contains("/afl-llvm/afl-llvm-ijon-pass.so"));
     }
 }


### PR DESCRIPTION
## Summary
- add an `AFLRS_NO_CMPLOG=1` build-time opt-out for AFL++ CmpLog LLVM plugin passes
- keep non-CmpLog AFL++ LLVM plugin passes enabled when opting out
- document the distinction between runtime `-c -` and compile-time CmpLog omission

Fixes #717.

## Verification
- `cargo fmt --check`
- `cargo test -p cargo-afl --bin cargo-afl`
- `cargo test -p cargo-afl --test clap --test crates_io`
- `cargo clippy -p cargo-afl --bin cargo-afl -- -D warnings`