### PR TITLE
Bump version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.18.2
+
+- [Add option to omit CmpLog instrumentation](https://github.com/rust-fuzz/afl.rs/pull/723)
+
 ## 0.18.1
 
 - [Honor `LLVM_CONFIG` environment variable if already set](https://github.com/rust-fuzz/afl.rs/commit/672467b36980ba4e31c9d0c09e186da893f5e2f7)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "afl"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "arbitrary",
  "home",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-afl"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-afl-common"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/afl/Cargo.toml
+++ b/afl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "afl"
-version = "0.18.1"
+version = "0.18.2"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [

--- a/cargo-afl-common/Cargo.toml
+++ b/cargo-afl-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-afl-common"
-version = "0.18.1"
+version = "0.18.2"
 readme = "README.md"
 license = "Apache-2.0"
 authors = ["Samuel Moelius <sam@moeli.us>"]

--- a/cargo-afl/Cargo.toml
+++ b/cargo-afl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-afl"
-version = "0.18.1"
+version = "0.18.2"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary
- bump afl, cargo-afl, and cargo-afl-common to 0.18.2
- update Cargo.lock package versions
- add a CHANGES.md entry for #723

## Verification
- cargo fmt --check
- cargo check --workspace --locked
- cargo test -p cargo-afl --bin cargo-afl
- cargo test -p cargo-afl --test clap --test crates_io