### PR TITLE
Update AFL++

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+      - name: Configure AFL child sync on macOS
+        if: runner.os == 'macOS'
+        run: echo "AFL_OLD_CHILD_SYNC=1" >> "$GITHUB_ENV"
       - name: Rustup
         run: rustup default ${{ matrix.toolchain }}
       - name: Install LLVM


### PR DESCRIPTION
This is #734 but with the `AFL_OLD_CHILD_SYNC=1` workaround mentioned in https://github.com/AFLplusplus/AFLplusplus/issues/2833#issuecomment-4816976644 to get CI to pass on macOS.